### PR TITLE
fix(documentation): modify centreon-plugins folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Inject centreon objects directly in database
 > :warning: **If you are not using docker**, you need to clone centreon-plugins repository on your virtual machine :
 > ```
 > git clone https://github.com/centreon/centreon-plugins.git
-> cp -R centreon-plugins/* /usr/lib/centreon/plugins/
+> cp -R centreon-plugins/src/* /usr/lib/centreon/plugins/
 > chmod +x /usr/lib/centreon/plugins/centreon_plugins.pl
 > ```
 


### PR DESCRIPTION
## Description

The prerequisite documentation specified a wrong directory for centreon-plugins setup

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

follow the README documentation to install prerequisites centreon-plugins
You will see problem when you 'll see output plugin in the centreon web ui

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
